### PR TITLE
KEYCLOAK-10120: enable statistics with env variable

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -421,7 +421,19 @@ containing a `crt` file and point `X509_CA_BUNDLE` environmental variable to tha
 
 NOTE: See `openshift-examples` directory for an out of the box setup for OpenShift.
 
+### Enable some metrics
 
+Keycloak image can collect some statistics for various subsystem which will then be available in the management console and the `/metrics` endpoint.
+You can enable it with the KEYCLOAK_STATISTICS environment variables which take a list of statistics to enable:
+* `db` for the `datasources` subsystem
+* `http` for the `undertow` subsystem
+* `jgroups` for the `jgroups` subsystem
+
+for instance, `KEYCLOAK_STATISTICS=db,http` will enable statistics for the datasources and undertow subsystem.
+
+The special value `all` enables all statistics.
+
+Once enabled, you should see the metrics values changing on the `/metrics` endpoint for the management endpoint.
 
 ## Other details
 

--- a/server/tools/cli/metrics/db.cli
+++ b/server/tools/cli/metrics/db.cli
@@ -1,0 +1,5 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=statistics-enabled, value=true)
+run-batch
+stop-embedded-server

--- a/server/tools/cli/metrics/http.cli
+++ b/server/tools/cli/metrics/http.cli
@@ -1,0 +1,5 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=undertow:write-attribute(name=statistics-enabled,value=true)
+run-batch
+stop-embedded-server

--- a/server/tools/cli/metrics/jgroups.cli
+++ b/server/tools/cli/metrics/jgroups.cli
@@ -1,0 +1,5 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=jgroups/channel=ee:write-attribute(name=statistics-enabled, value=true)
+run-batch
+stop-embedded-server

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -76,6 +76,14 @@ if [ -z "$BIND_OPTS" ]; then
 fi
 SYS_PROPS+=" $BIND_OPTS"
 
+#########################################
+# Expose management console for metrics #
+#########################################
+
+if [ -n "$KEYCLOAK_STATISTICS" ] ; then 
+    SYS_PROPS+=" -Djboss.bind.address.management=0.0.0.0"
+fi
+
 #################
 # Configuration #
 #################
@@ -199,6 +207,7 @@ fi
 
 /opt/jboss/tools/x509.sh
 /opt/jboss/tools/jgroups.sh
+/opt/jboss/tools/statistics.sh
 /opt/jboss/tools/autorun.sh
 
 ##################

--- a/server/tools/statistics.sh
+++ b/server/tools/statistics.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -n "$KEYCLOAK_STATISTICS" ]; then
+   IFS=',' read -ra metrics <<< "$KEYCLOAK_STATISTICS"
+   for file in /opt/jboss/tools/cli/metrics/*.cli; do
+      name=${file##*/}
+      base=${name%.cli}
+      if [[  $KEYCLOAK_STATISTICS == *"$base"* ]] || [[  $KEYCLOAK_STATISTICS == *"all"* ]];  then
+         $JBOSS_HOME/bin/jboss-cli.sh --file="$file" >& /dev/null
+      fi
+   done
+fi


### PR DESCRIPTION
The CLI is run at runtime, when all the other configuration is done (jgroups and database). This allows to have all this configuration in an unique file instead of in all others cli commands.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
