### PR TITLE
KEYCLOAK-10151 Allow configuration of owner count for the distributed caches

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -369,6 +369,19 @@ This can be easily achieved by extending the Keycloak image and adding just one 
 
 Of course, we highly encourage you to contribute your custom scripts back to the community image!
 
+### Replication and Fail-Over
+
+By default Keycloak does NOT replicate caches like sessions, authenticationSessions, offlineSessions, loginFailures and a few others (See Eviction and Expiration for more details), which are configured as distributed caches when using a clustered setup. Entries are not replicated to every single node, but instead one or more nodes is chosen as an owner of that data. If a node is not the owner of a specific cache entry it queries the cluster to obtain it. What this means for failover is that if all the nodes that own a piece of data go down, that data is lost forever. By default, Keycloak only specifies one owner for data. So if that one node goes down that data is lost. This usually means that users will be logged out and will have to login again. For more on this subject see [Keycloak Documentation](https://www.keycloak.org/docs/latest/server_installation/#_replication)
+
+#### Specify destributed-cache owners
+
+* `CACHE_OWNERS_COUNT`: Specify the number of distributed-cache owners (default is 1)
+
+AuthenticationSessions will not be replicated by setting CACHE_OWNERS_COUNT>1 as this is usually not required/intended (https://www.keycloak.org/docs/latest/server_installation/#cache)
+To enable replication of AuthenticationSessions as well use:
+
+ * `CACHE_OWNERS_AUTH_SESSIONS_COUNT`: Specify the number of replicas for AuthenticationSessions
+
 
 ## Misc
 

--- a/server/tools/cli/infinispan/cache-owners.cli
+++ b/server/tools/cli/infinispan/cache-owners.cli
@@ -1,0 +1,11 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=sessions: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineSessions: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=loginFailures: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=clientSessions: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineClientSessions: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=actionTokens: write-attribute(name=owners, value=${env.CACHE_OWNERS_COUNT:1})
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=authenticationSessions: write-attribute(name=owners, value=${env.CACHE_OWNERS_AUTH_SESSIONS_COUNT:1})
+run-batch
+stop-embedded-server

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -211,6 +211,7 @@ fi
 
 /opt/jboss/tools/x509.sh
 /opt/jboss/tools/jgroups.sh
+/opt/jboss/tools/infinispan.sh
 /opt/jboss/tools/statistics.sh
 /opt/jboss/tools/autorun.sh
 

--- a/server/tools/infinispan.sh
+++ b/server/tools/infinispan.sh
@@ -1,0 +1,14 @@
+# How many owners / replicas should our distributed caches have. If <2 any node that is removed from the cluster will cause a data-loss!
+# As it is only sensible to replicate AuthenticationSessions for certain cases, their replication factor can be configured independently
+
+if [ -n "$CACHE_OWNERS_COUNT" ]; then
+    echo "Setting cache owners to $CACHE_OWNERS_COUNT replicas"
+
+    # Check and log the replication factor of AuthenticationSessions, otherwise this is set to 1 by default
+    if [ -n "$CACHE_OWNERS_AUTH_SESSIONS_COUNT" ]; then
+        echo "Enabling replication of AuthenticationSessions with ${CACHE_OWNERS_AUTH_SESSIONS_COUNT} replicas"
+    else
+        echo "AuthenticationSessions will NOT be replicated, set CACHE_OWNERS_AUTH_SESSIONS_COUNT to configure this"
+    fi
+$JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/infinispan/cache-owners.cli" >& /dev/null
+fi


### PR DESCRIPTION
Issue KEYCLOAK-7582 introduced support for standalone-ha type of clusters via i.e. DNS_PING. Unfortunately the number of owners to the distributed-cache is "1" by default causing data-loss at shutdown of any node. See: https://www.keycloak.org/docs/5.0/server_installation/#_replication

Especially in a container environment like on Kubernetes / OpenShift it just seems natural to have an owner count of 2 or 3 to allow not just for downtime-free, but also data-loss-free rolling updates / reconfiguration of a Keycloak cluster.

Configuration of the owners count was already implemented by in a previous PR by https://github.com/rayscunningham regarding clustering - https://github.com/jboss-dockerfiles/keycloak/pull/96 - but this was closed in favor of https://github.com/jboss-dockerfiles/keycloak/pull/151 later which did not allow such configuration.
