### PR TITLE
Fixed outdated information in README.md

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -97,9 +97,9 @@ Generic variable names can be used to configure any Database type, defaults may 
 - `DB_PORT`: Specify port of the database (optional, default is DB vendor default port)
 - `DB_DATABASE`: Specify name of the database to use (optional, default is `keycloak`).
 - `DB_SCHEMA`: Specify name of the schema to use for DB that support schemas (optional, default is public on Postgres).
-- `DB_USER`: Specify user to use to authenticate to the database (optional, default is `keycloak`).
+- `DB_USER`: Specify user to use to authenticate to the database (optional, default is ``).
 - `DB_USER_FILE`: Specify user to authenticate to the database via file input (alternative to `DB_USER`).
-- `DB_PASSWORD`: Specify user's password to use to authenticate to the database (optional, default is `password`).
+- `DB_PASSWORD`: Specify user's password to use to authenticate to the database (optional, default is ``).
 - `DB_PASSWORD_FILE`: Specify user's password to use to authenticate to the database via file input (alternative to `DB_PASSWORD`).
 
 ### MySQL Example


### PR DESCRIPTION
In version 5.0.0 default values for environment variables `DB_USER` and `DB_PASSWORD` were `keycloak` and `password`, which is no longer the case in 6.0.0.
Starting from version 6.0.0 not setting `DB_USER` will cause an error: "WFLYCTL0113: '' is an invalid value for parameter user-name. Values must have a minimum length of 1 characters".
So I think the information in https://hub.docker.com/r/jboss/keycloak and https://github.com/jboss-dockerfiles/keycloak/blob/master/server/README.md is misleading and should be updated according to the changes in new versions.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
