### PR TITLE
[KEYCLOAK-10059] Use ubi8-minimal instead of base-jdk as base image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/base-jdk:8
+FROM registry.redhat.io/ubi8-minimal
 
 ENV KEYCLOAK_VERSION 6.0.1
 ENV JDBC_POSTGRES_VERSION 42.2.5
@@ -17,7 +17,7 @@ ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloa
 
 USER root
 
-RUN yum update -y && yum install -y epel-release git && yum install -y jq openssl which && yum clean all
+RUN microdnf update -y && microdnf install -y gzip hostname java-11-openjdk-headless openssl tar which && microdnf clean all
 
 ADD tools /opt/jboss/tools
 RUN /opt/jboss/tools/build-keycloak.sh

--- a/server/tools/build-keycloak.sh
+++ b/server/tools/build-keycloak.sh
@@ -9,6 +9,9 @@ if [ "$GIT_REPO" != "" ]; then
         GIT_BRANCH="master"
     fi
 
+    # Install Git
+    microdnf install -y git
+
     # Install Maven
     cd /opt/jboss 
     curl -s https://apache.uib.no/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz | tar xz
@@ -88,5 +91,5 @@ rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 # Set permissions #
 ###################
 
-chown -R jboss:0 /opt/jboss/keycloak
-chmod -R g+rw /opt/jboss/keycloak
+chgrp -R 0 /opt/jboss/keycloak
+chmod -R g=u /opt/jboss/keycloak


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
