### PR TITLE
KEYCLOAK-11419 Vault support in Docker

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -383,6 +383,13 @@ To enable replication of AuthenticationSessions as well use:
  * `CACHE_OWNERS_AUTH_SESSIONS_COUNT`: Specify the number of replicas for AuthenticationSessions
 
 
+## Vault
+
+### Setup Kubernetes / OpenShift files plaintext vault
+
+Keycloak supports vault implementation for [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/). To use files plaintext vault in Docker container mount secret files to `$JBOSS_HOME/secrets` directory. This can be used to consume secrets from Kubernetes / OpenShift cluster. 
+
+
 ## Misc
 
 ### Specify hostname

--- a/server/tools/cli/files-plaintext-vault.cli
+++ b/server/tools/cli/files-plaintext-vault.cli
@@ -1,0 +1,6 @@
+embed-server --server-config=$configuration_file --std-out=discard
+echo ** Adding vault spi **
+/subsystem=keycloak-server/spi=vault/:add
+/subsystem=keycloak-server/spi=vault/provider=files-plaintext/:add(enabled=true,properties={dir => $plaintext_vault_provider_dir})
+stop-embedded-server
+

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -214,6 +214,7 @@ fi
 /opt/jboss/tools/infinispan.sh
 /opt/jboss/tools/statistics.sh
 /opt/jboss/tools/autorun.sh
+/opt/jboss/tools/vault.sh
 
 ##################
 # Start Keycloak #

--- a/server/tools/vault.sh
+++ b/server/tools/vault.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -d "$JBOSS_HOME/secrets" ]; then
+    echo "set plaintext_vault_provider_dir=${JBOSS_HOME}/secrets" >> "$JBOSS_HOME/bin/.jbossclirc"
+
+    echo "set configuration_file=standalone.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+    $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/files-plaintext-vault.cli
+    sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+
+    echo "set configuration_file=standalone-ha.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
+    $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/files-plaintext-vault.cli
+    sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+fi


### PR DESCRIPTION
This PR requires Keycloak version 8.0.0 where the vault support is present. 