### PR TITLE
[KEYCLOAK-11622] Make the user/password handling more safe for whitespace

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -33,8 +33,8 @@ file_env() {
 file_env 'KEYCLOAK_USER'
 file_env 'KEYCLOAK_PASSWORD'
 
-if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
-    /opt/jboss/keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+if [ -n "$KEYCLOAK_USER" ] && [ -n "$KEYCLOAK_PASSWORD" ]; then
+    /opt/jboss/keycloak/bin/add-user-keycloak.sh --user "$KEYCLOAK_USER" --password "$KEYCLOAK_PASSWORD"
 fi
 
 ############


### PR DESCRIPTION
 Make the user/password handling more safe for whitespace in user or password. This wraps them both in ".

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
