### PR TITLE
Backport of [KEYCLOAK-11636] Switched to ubi8 image that doesn't require a redhat account and added the jboss user

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal
 
 ENV KEYCLOAK_VERSION 7.0.0
 ENV JDBC_POSTGRES_VERSION 42.2.5

--- a/server/tools/build-keycloak.sh
+++ b/server/tools/build-keycloak.sh
@@ -72,7 +72,7 @@ cp /opt/jboss/tools/databases/oracle/module.xml .
 
 mkdir -p /opt/jboss/keycloak/modules/system/layers/keycloak/com/microsoft/sqlserver/jdbc/main
 cd /opt/jboss/keycloak/modules/system/layers/keycloak/com/microsoft/sqlserver/jdbc/main
-curl -L http://central.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/$JDBC_MSSQL_VERSION/mssql-jdbc-$JDBC_MSSQL_VERSION.jar > mssql-jdbc.jar
+curl -L https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/$JDBC_MSSQL_VERSION/mssql-jdbc-$JDBC_MSSQL_VERSION.jar > mssql-jdbc.jar
 cp /opt/jboss/tools/databases/mssql/module.xml .
 
 ######################
@@ -91,5 +91,6 @@ rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 # Set permissions #
 ###################
 
-chgrp -R 0 /opt/jboss/keycloak
-chmod -R g=u /opt/jboss/keycloak
+echo "jboss:x:1000:1000:JBoss user:/opt/jboss:/sbin/nologin" >> /etc/passwd
+chown -R jboss:0 /opt/jboss
+chmod -R g+rw /opt/jboss


### PR DESCRIPTION
- Update of released versions

Depends on https://github.com/keycloak/keycloak-containers/pull/227