### PR TITLE
Fix the path for the add-user-keycloak.sh script

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -29,7 +29,7 @@ you need to use environment variables to pass in an initial username and passwor
 
 You can also create an account on an already running container by running:
 
-    docker exec <CONTAINER> keycloak/bin/add-user-keycloak.sh -u <USERNAME> -p <PASSWORD>
+    docker exec <CONTAINER> /opt/jboss/keycloak/bin/add-user-keycloak.sh -u <USERNAME> -p <PASSWORD>
 
 Then restarting the container:
 


### PR DESCRIPTION
Without the absolute path, we get an error from the docker engine.

```
> docker exec <CONTAINER> keycloak/bin/add-user-keycloak.sh -u user -p password
OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec: \"keycloak/bin/add-user-keycloak.sh\": stat keycloak/bin/add-user-keycloak.sh: no such file or directory": unknown
```

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
