### PR TITLE
Added info to change CONSOLE log level via jboss-cli

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -416,6 +416,7 @@ Supported log levels are `ALL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE
 
 Log level can also be changed at runtime, for example (assuming docker exec access):
 
+    ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/console-handler=CONSOLE:change-log-level(level=DEBUG)'
     ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/root-logger=ROOT:change-root-log-level(level=DEBUG)'
     ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/logger=org.keycloak:write-attribute(name=level,value=DEBUG)'
 


### PR DESCRIPTION
It is not enough to change the log level of the ROOT or a individual
logger to change the log level on the Docker container at runtime.
Also the CONSOLE log level has to be adapted accordingly. This info
was added to the README.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
