### PR TITLE
KEYCLOAK-12387 Add jboss group

### DIFF
--- a/server/tools/build-keycloak.sh
+++ b/server/tools/build-keycloak.sh
@@ -91,6 +91,7 @@ rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 # Set permissions #
 ###################
 
+echo "jboss:x:1000:jboss" >> /etc/group
 echo "jboss:x:1000:1000:JBoss user:/opt/jboss:/sbin/nologin" >> /etc/passwd
-chown -R jboss:0 /opt/jboss
+chown -R jboss:jboss /opt/jboss
 chmod -R g+rw /opt/jboss


### PR DESCRIPTION
With KEYCLOAK-10059 the base image has been changed to ubi8-minimal.
Since ubi8-minimal does not ship with a user named 'jboss', the user
will be created in the startup scripts. However, the previously used
image jboss/base-jdk also ships with a group named 'jboss', the
ubi8-minimal image does not. With KEYCLOAK-10059 this group
does not get created

For backwards compatibility a group named 'jboss' has been added and
the user 'jboss' has been associated as a member of that group.