### PR TITLE
KEYCLOAK-12947 new docker compose example

### DIFF
--- a/docker-compose-examples/README.md
+++ b/docker-compose-examples/README.md
@@ -17,6 +17,19 @@ Open http://localhost:8080/auth and login as user 'admin' with password 'Pa55w0r
 Note - If you run the example twice without removing the persisted volume there will be a warning 'user with username exists'. You can ignore this warning.
 
 
+## Keycloak and PostgreSQL with JDBC_PING
+
+Similarly to other templates, the `keycloak-postgres-jdbc-ping.yml` template creates a volume for PostgreSQL and boots up Keycloak connected to it. Traefik is used like load balancer to redirect all request to diferent container instances. The most important change is the JGroups Discovery protocol that is used in this configuration, which is `JDBC_PING`. `JDBC_PING` reuses the same database instance as all Keycloak servers in the cluster.
+
+Run the example with the following command:
+
+    docker-compose -f keycloak-postgres-jdbc-ping.yml up --scale keycloak=2
+
+Once the cluster is started, open http://localhost:8080/auth and login as user 'admin' with password 'Pa55w0rd'.
+
+Note - Sometimes, it is necessary to adjust the `JDBC_PING` initialization SQL (see the [manual](http://jgroups.org/manual/#_jdbc_ping)). In such cases, make sure you specify proper `initialize_sql` string into `JGROUPS_DISCOVERY_PROPERTIES` property. For more information, please refer to [JGroups codebase](https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/JDBC_PING.java).
+
+
 
 ## Keycloak and MySQL
 
@@ -43,14 +56,14 @@ Note - Sometimes, it is necessary to adjust the `JDBC_PING` initialization SQL (
 
 ## Keycloak and Microsoft SQL Server
 
-The `keycloak-mssql.yml` template creates a volume for Microsoft SQL Server and starts Keycloak connected to a Microsoft SQL Server instance. 
+The `keycloak-mssql.yml` template creates a volume for Microsoft SQL Server and starts Keycloak connected to a Microsoft SQL Server instance.
 
 Run the example with the following command:
 
     docker-compose -f keycloak-mssql.yml up
-    
+
 Note - This example uses an additional container to create the keycloak database prior to loading the keycloak application.  In addition, the keycloak container can be rebuilt using
-    
+
     docker-compose -f ./docker-compose-examples/keycloak-mssql.yml build
 
 

--- a/docker-compose-examples/keycloak-postgres-jdbc-ping.yml
+++ b/docker-compose-examples/keycloak-postgres-jdbc-ping.yml
@@ -1,0 +1,58 @@
+version: '3'
+
+volumes:
+  postgres_data:
+    driver: local
+
+services:
+  postgres:
+    image: 'postgres:alpine'
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
+    restart: 'always'
+    # ports:
+    #   - 5432:5432
+    environment:
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: keycloak
+      POSTGRES_HOST: postgres
+
+  traefik:
+    image: library/traefik:alpine
+    container_name: traefik
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: >
+      --logLevel=ERROR
+      --api.dashboard
+      --docker
+      --entrypoints="Name:http Address::80"
+      --defaultentrypoints="http"
+    ports:
+      - 80:80
+      - 3000:8080
+
+  keycloak:
+    image: jboss/keycloak
+    environment:
+      DB_VENDOR: postgres
+      DB_ADDR: postgres
+      DB_PORT: 5432
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: password
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: Pa55w0rd
+      # KEYCLOAK_LOGLEVEL: DEBUG
+      JGROUPS_DISCOVERY_PROTOCOL: JDBC_PING
+      JGROUPS_DISCOVERY_PROPERTIES: datasource_jndi_name=java:jboss/datasources/KeycloakDS,info_writer_sleep_time=500,initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, created timestamp default current_timestamp, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))"
+    depends_on:
+      - postgres
+    labels:
+      traefik.enable: true
+      traefik.port: 8080
+      traefik.protocol: http
+      traefik.frontend.rule: Host:localhost
+      traefik.frontend.passHostHeader: true
+      # traefik.backend.loadbalancer.stickiness: true


### PR DESCRIPTION
added a new example to run keycloak in HA mode with postgres database and jdbc_ping discovery protocol