### PR TITLE
KEYCLOAK-12737 Offline scripts clarification in manual

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -283,7 +283,7 @@ To run custom scripts on container startup place a file in the `/opt/jboss/start
 
 Two types of scripts are supported:
 
-* WildFly `.cli` [scripts](https://docs.jboss.org/author/display/WFLY/Command+Line+Interface)
+* WildFly `.cli` [scripts](https://docs.jboss.org/author/display/WFLY/Command+Line+Interface). In most of the cases, the scripts should operate in [offline mode](https://wildfly.org/news/tags/CLI/) (using `embed-server` instruction). It's also worth to mention, that by default, keycloak uses `standalone-ha.xml` configuration (unless other server configuration is specified).
 
 * Any executable (`chmod +x`) script
 


### PR DESCRIPTION
[KEYCLOAK-12737](https://issues.redhat.com/browse/KEYCLOAK-12737)

This Pull Request contains a small clarification in the manual, that most of the custom scripts should use offline mode.