### PR TITLE
KEYCLOAK-12777 add ability to set fixed admin console url

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -398,6 +398,12 @@ To set a fixed base URL for frontend requests use the following environment valu
 
 * `KEYCLOAK_FRONTEND_URL`: Specify base URL for Keycloak (optional, default is retrieved from request)
 
+### Specify admin URL
+
+If you do not want to expose the admin endpoints and console on the public domain use the property `KEYCLOAK_ADMIN_URL` to set a fixed URL for the admin console, which is different to the `KEYCLOAK_FRONTEND_URL`. It is also required to block access to /auth/admin externally
+
+* `KEYCLOAK_ADMIN_URL`: Specify fixed URL for Keycloak Admin Console(optional)
+
 ### Specify hostname
 
 This environment variable is deprecated, use `KEYCLOAK_FRONTEND_URL` instead. 

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -48,6 +48,10 @@ if [[ -n ${KEYCLOAK_FRONTEND_URL:-} ]]; then
     SYS_PROPS+="-Dkeycloak.frontendUrl=$KEYCLOAK_FRONTEND_URL"
 fi
 
+if [[ -n ${KEYCLOAK_ADMIN_URL:-} ]]; then
+    SYS_PROPS+="-Dkeycloak.adminUrl=$KEYCLOAK_ADMIN_URL"
+fi
+
 if [[ -n ${KEYCLOAK_HOSTNAME:-} ]]; then
     SYS_PROPS+="-Dkeycloak.hostname.provider=fixed -Dkeycloak.hostname.fixed.hostname=$KEYCLOAK_HOSTNAME"
 


### PR DESCRIPTION
[KEYCLOAK-12777](https://issues.redhat.com/browse/KEYCLOAK-12777)
This pull requests adds new KEYCLOAK_ADMIN_URL docker container and pass it to keycloak.adminUrl property