### PR TITLE
[KEYCLOAK-12879] Google identity provider doesn't handle non-ascii characters

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,7 +17,7 @@ ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloa
 
 USER root
 
-RUN microdnf update -y && microdnf install -y gzip hostname java-11-openjdk-headless openssl tar which && microdnf clean all
+RUN microdnf update -y && microdnf install -y glibc-langpack-en gzip hostname java-11-openjdk-headless openssl tar which && microdnf clean all
 
 ADD tools /opt/jboss/tools
 RUN /opt/jboss/tools/build-keycloak.sh


### PR DESCRIPTION
This pull request installs `glibc-langpack-en` package because locale files was not installed.