### PR TITLE
KEYCLOAK-12892 Use dedicated datasource attribute for JDBC_PING

### DIFF
--- a/docker-compose-examples/keycloak-mariadb-jdbc-ping.yml
+++ b/docker-compose-examples/keycloak-mariadb-jdbc-ping.yml
@@ -28,6 +28,5 @@ services:
         KEYCLOAK_USER: admin
         KEYCLOAK_PASSWORD: Pa55w0rd
         JGROUPS_DISCOVERY_PROTOCOL: JDBC_PING
-        JGROUPS_DISCOVERY_PROPERTIES: datasource_jndi_name=java:jboss/datasources/KeycloakDS,info_writer_sleep_time=500
       depends_on:
         - mariadb

--- a/server/tools/cli/jgroups/discovery/JDBC_PING.cli
+++ b/server/tools/cli/jgroups/discovery/JDBC_PING.cli
@@ -1,0 +1,11 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=jgroups/stack=udp/protocol=PING:remove()
+/subsystem=jgroups/stack=udp/protocol=JDBC_PING:add(add-index=0, data-source=KeycloakDS, properties=$keycloak_jgroups_discovery_protocol_properties)
+
+/subsystem=jgroups/stack=tcp/protocol=MPING:remove()
+/subsystem=jgroups/stack=tcp/protocol=JDBC_PING:add(add-index=0, data-source=KeycloakDS, properties=$keycloak_jgroups_discovery_protocol_properties)
+
+/subsystem=jgroups/channel=ee:write-attribute(name="stack", value=$keycloak_jgroups_transport_stack)
+run-batch
+stop-embedded-server


### PR DESCRIPTION
[KEYCLOAK-12892](https://issues.redhat.com/browse/KEYCLOAK-12892)

Our `JDBC_PING` examples use a generic JNDI Datasource attribute. As mentioned in [WFLY-12948](https://issues.redhat.com/browse/WFLY-12948), we should use a dedicated attribute for this.