### PR TITLE
KEYCLOAK-13020 Permissions update

### DIFF
--- a/server/tools/build-keycloak.sh
+++ b/server/tools/build-keycloak.sh
@@ -87,14 +87,18 @@ rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 bin/jboss-cli.sh --file=/opt/jboss/tools/cli/standalone-ha-configuration.cli
 rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 
+###########
+# Garbage #
+###########
+
+rm -rf /opt/jboss/keycloak/standalone/tmp/auth
+rm -rf /opt/jboss/keycloak/domain/tmp/auth
+
 ###################
 # Set permissions #
 ###################
 
-echo "jboss:x:1000:jboss" >> /etc/group
-echo "jboss:x:1000:1000:JBoss user:/opt/jboss:/sbin/nologin" >> /etc/passwd
-chown -R jboss:jboss /opt/jboss
-chmod -R g+rw /opt/jboss
-
-rm -rf /opt/jboss/keycloak/standalone/tmp/auth
-rm -rf /opt/jboss/keycloak/domain/tmp/auth
+echo "jboss:x:0:root" >> /etc/group
+echo "jboss:x:1000:0:JBoss user:/opt/jboss:/sbin/nologin" >> /etc/passwd
+chown -R jboss:root /opt/jboss
+chmod -R g+rwX /opt/jboss


### PR DESCRIPTION
[KEYCLOAK-13020](https://issues.redhat.com/browse/KEYCLOAK-13020)

This Pull Request uses a more restrictive way of setting permissions proposed by @douglaspalmer in https://github.com/keycloak/keycloak-containers/pull/258. 

You may play with it using this image: `docker.io/slaskawi/keycloak:KEYCLOAK-13020-2`

Unfortunately there are some cons to this approach. It doesn't fully fix [KEYCLOAK-13020](https://issues.redhat.com/browse/KEYCLOAK-13020). Users will always need to run this container with a user, who uses group id equal to `0` (root). This way, they will simulate, how OpenShift does it: https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html
