### PR TITLE
Add properties to enable upload script during import

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -70,6 +70,7 @@ fi
 
 if [[ -n ${KEYCLOAK_IMPORT:-} ]]; then
     SYS_PROPS+=" -Dkeycloak.import=$KEYCLOAK_IMPORT"
+    SYS_PROPS+=" -Dkeycloak.profile.feature.upload_scripts=enabled"    
 fi
 
 ########################


### PR DESCRIPTION
Importing from an app does not work without uploading scripts.
