### PR TITLE
KEYCLOAK-13391 Error accessing Keycloak when KEYCLOAK_FRONTEND_URL and KEYCLOAK_HOSTNAME are both set

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -49,7 +49,7 @@ if [[ -n ${KEYCLOAK_FRONTEND_URL:-} ]]; then
 fi
 
 if [[ -n ${KEYCLOAK_HOSTNAME:-} ]]; then
-    SYS_PROPS+="-Dkeycloak.hostname.provider=fixed -Dkeycloak.hostname.fixed.hostname=$KEYCLOAK_HOSTNAME"
+    SYS_PROPS+=" -Dkeycloak.hostname.provider=fixed -Dkeycloak.hostname.fixed.hostname=$KEYCLOAK_HOSTNAME"
 
     if [[ -n ${KEYCLOAK_HTTP_PORT:-} ]]; then
         SYS_PROPS+=" -Dkeycloak.hostname.fixed.httpPort=$KEYCLOAK_HTTP_PORT"


### PR DESCRIPTION
When KEYCLOAK_FRONTEND_URL and KEYCLOAK_HOSTNAME environment variables are both set, the command line is wrong because of a missing space. 

Example: 
```
java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED -Dorg.jboss.boot.log.file=/opt/jboss/keycloak/standalone/log/server.log -Dlogging.configuration=file:/opt/jboss/keycloak/standalone/configuration/logging.properties -jar /opt/jboss/keycloak/jboss-modules.jar -mp /opt/jboss/keycloak/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/keycloak -Djboss.server.base.dir=/opt/jboss/keycloak/standalone -Dkeycloak.frontendUrl=http://myapp.lan/auth-Dkeycloak.hostname.provider=fixed -Dkeycloak.hostname.fixed.hostname=keycloak -Dkeycloak.hostname.fixed.httpPort=8080 -Dkeycloak.hostname.fixed.httpsPort=8080 -Djboss.bind.address=172.16.0.16 -Djboss.bind.address.private=172.16.0.16 -c=standalone-ha.xml -b 0.0.0.0
```

By consequence, the value of `keycloak.frontendUrl` is wrongly set and we fail accessing Keycloak.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
