### PR TITLE
WIP: Fix keycloak container restart issues

### DIFF
--- a/server/tools/cli/databases/mariadb/change-database.cli
+++ b/server/tools/cli/databases/mariadb/change-database.cli
@@ -6,4 +6,6 @@
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
-/subsystem=datasources/jdbc-driver=mariadb:add(driver-name=mariadb, driver-module-name=org.mariadb.jdbc, driver-xa-datasource-class-name=org.mariadb.jdbc.MySQLDataSource)
+
+/subsystem=datasources/jdbc-driver=mariadb: remove()
+/subsystem=datasources/jdbc-driver=mariadb: add(driver-name=mariadb, driver-module-name=org.mariadb.jdbc, driver-xa-datasource-class-name=org.mariadb.jdbc.MySQLDataSource)

--- a/server/tools/cli/databases/mssql/change-database.cli
+++ b/server/tools/cli/databases/mssql/change-database.cli
@@ -6,4 +6,6 @@
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
-/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver.jdbc,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)
+
+/subsystem=datasources/jdbc-driver=sqlserver: remove()
+/subsystem=datasources/jdbc-driver=sqlserver: add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver.jdbc,driver-xa-datasource-class-name=com.microsoft.sqlserver.jdbc.SQLServerXADataSource)

--- a/server/tools/cli/databases/mysql/change-database.cli
+++ b/server/tools/cli/databases/mysql/change-database.cli
@@ -6,4 +6,6 @@
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
-/subsystem=datasources/jdbc-driver=mysql:add(driver-name=mysql, driver-module-name=com.mysql.jdbc, driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+
+/subsystem=datasources/jdbc-driver=mysql: remove()
+/subsystem=datasources/jdbc-driver=mysql: add(driver-name=mysql, driver-module-name=com.mysql.jdbc, driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)

--- a/server/tools/cli/databases/oracle/change-database.cli
+++ b/server/tools/cli/databases/oracle/change-database.cli
@@ -6,4 +6,6 @@
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
-/subsystem=datasources/jdbc-driver=oracle:add(driver-name=oracle, driver-module-name=com.oracle.jdbc, driver-xa-datasource-class-name=oracle.jdbc.xa.client.OracleXADataSource)
+
+/subsystem=datasources/jdbc-driver=oracle: remove()
+/subsystem=datasources/jdbc-driver=oracle: add(driver-name=oracle, driver-module-name=com.oracle.jdbc, driver-xa-datasource-class-name=oracle.jdbc.xa.client.OracleXADataSource)

--- a/server/tools/cli/databases/postgres/change-database.cli
+++ b/server/tools/cli/databases/postgres/change-database.cli
@@ -6,6 +6,8 @@
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
-/subsystem=datasources/jdbc-driver=postgresql:add(driver-name=postgresql, driver-module-name=org.postgresql.jdbc, driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+
+/subsystem=datasources/jdbc-driver=postgresql: remove()
+/subsystem=datasources/jdbc-driver=postgresql: add(driver-name=postgresql, driver-module-name=org.postgresql.jdbc, driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
 
 /subsystem=keycloak-server/spi=connectionsJpa/provider=default:write-attribute(name=properties.schema,value=${env.DB_SCHEMA:public})

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -219,6 +219,8 @@ if [ "$DB_VENDOR" != "h2" ]; then
     /bin/sh /opt/jboss/tools/databases/change-database.sh $DB_VENDOR
 fi
 
+sed -i '/^set keycloak/d' "${JBOSS_HOME}/bin/.jbossclirc"
+
 /opt/jboss/tools/x509.sh
 /opt/jboss/tools/jgroups.sh
 /opt/jboss/tools/infinispan.sh

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -25,6 +25,8 @@ function autogenerate_keystores() {
 
       echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
 
+      rm -f "${JKS_KEYSTORE_FILE}" "${PKCS12_KEYSTORE_FILE}"
+
       openssl pkcs12 -export \
       -name "${NAME}" \
       -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
@@ -64,6 +66,9 @@ function autogenerate_keystores() {
   if [ -n "${X509_CA_BUNDLE}" ]; then
     pushd /tmp >& /dev/null
     echo "Creating Keycloak truststore.."
+
+    rm -f "${JKS_TRUSTSTORE_PATH}"
+
     # We use cat here, so that users could specify multiple CA Bundles using space or even wildcard:
     # X509_CA_BUNDLE=/var/run/secrets/kubernetes.io/serviceaccount/*.crt
     # Note, that there is no quotes here, that's intentional. Once can use spaces in the $X509_CA_BUNDLE like this:


### PR DESCRIPTION
When container restarts these issues occur:
* scripts (x509.sh, jgroups.sh etc) append configuration to .jbossclirc again
* jdbc-driver is attempted to be added even if it's already present in standalone-ha.xml
* x509.sh tries to access existsing truststores with new random passwords and append certs/keys on each container start