### PR TITLE
x509.sh: add message about key permissions

### DIFF
--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -41,6 +41,8 @@ function autogenerate_keystores() {
 
       if [ -f "${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" ]; then
         echo "${KEYSTORES[$KEYSTORE_TYPE]} keystore successfully created at: ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}"
+      else
+        echo "${KEYSTORES[$KEYSTORE_TYPE]} keystore not created at: ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE} (check permissions?)"
       fi
 
       echo "set keycloak_tls_keystore_password=${PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
@@ -77,6 +79,8 @@ function autogenerate_keystores() {
 
     if [ -f "${JKS_TRUSTSTORE_PATH}" ]; then
       echo "Keycloak truststore successfully created at: ${JKS_TRUSTSTORE_PATH}"
+    else
+      echo "Keycloak truststore not created at: ${JKS_TRUSTSTORE_PATH}"
     fi
 
     # Import existing system CA certificates into the newly generated truststore


### PR DESCRIPTION
Add message about key permissions if ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE} is not created.

When starting with something like "docker run .... -v .../key.pem:/etc/x509/https/tls.key quay.io/keycloak/keycloak:latest" if the key (${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}) is not created, for some reasons including permissions issues, no message is displayed and SSL is started in a broken state. This shows a warning message to help identify the issue.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
