### PR TITLE
INTLY-8355 Better error logs on failed extension download

### DIFF
--- a/keycloak-init-container/extensions.sh
+++ b/keycloak-init-container/extensions.sh
@@ -13,23 +13,42 @@ download_extension() {
     if [[ -z "$EXTENSION_URL" ]]; then
         return
     fi
-
+    echo 
     echo "Downloading extension from $EXTENSION_URL"
-    local FILENAME="$(curl --verbose --location --remote-name --remote-header-name --write-out '%{filename_effective}' --silent "$EXTENSION_URL" 2> /tmp/headers)"
+    local CURL_COMMAND="$(curl --verbose --location  --remote-name --remote-header-name --write-out "%{http_code} %{filename_effective}"  --silent "$EXTENSION_URL" 2> /tmp/headers)"
+  
+    local STATUS_CODE=${CURL_COMMAND:0:3}
 
-    # Try to get the filename from the response headers and return
-    # a random name if that fails
-    if ! grep -q -i '^< content-disposition:.*filename=' /tmp/headers ; then
-        local F="$(od -N8 -tx1 -An -v /dev/urandom | tr -d " \n").jar"
-        mv "$FILENAME" "$F"
-        FILENAME="$F"
+    if [ $STATUS_CODE -eq "200" ]; then
+        local FILENAME=${CURL_COMMAND:4}
+        echo "Extension downloaded successfully"
+
+        # Try to get the filename from the response headers and return
+        # a random name if that fails
+        if ! grep -q -i '^< content-disposition:.*filename=' /tmp/headers ; then
+            local F="$(od -N8 -tx1 -An -v /dev/urandom | tr -d "").jar"
+            mv "$FILENAME" "$F"
+            FILENAME="$F"
+        fi
+        echo " --> $FILENAME"
+    else
+        echo -e "Can not download the extension: $EXTENSION_URL\nError code: $STATUS_CODE"
+        ((STATUS+=1))
     fi
 
-    echo " --> $FILENAME"
 }
 
 # Parse the environment variable and download the extensions from the list
 IFS=,
-for EXT in $KEYCLOAK_EXTENSIONS ; do
+STATUS=0
+for EXT in ${KEYCLOAK_EXTENSION[@]} ; do
     download_extension "$EXT"
 done
+if [ "$STATUS" -ne 0 ]; then
+    echo
+    echo -e "Extensions.sh script failed at downloading all required extensions, number of failed downloads: $STATUS \n"
+    exit 1
+else
+    echo
+    echo -e "All extensions downloaded successfully \n"
+fi


### PR DESCRIPTION
## Description
This is a slight refactor of the extensions.sh script.

## Changes
Report extension download failure when the curl response code is different than 200. For example, if github.com is currently down and the extension can not be downloaded.

## Why
Previously, download failure was ignored and KeyCloak was started without the required plugin. 

Jira associated with the issue: https://issues.redhat.com/browse/INTLY-8355
