### PR TITLE
KEYCLOAK-15387 Add user and generate password for them, if user and password not passed

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -22,10 +22,23 @@ To be able to open Keycloak on localhost map port 8080 locally
 
 ## Creating admin account
 
-By default there is no admin user created so you won't be able to login to the admin console. To create an admin account
-you need to use environment variables to pass in an initial username and password. This is done by running:
+To be able to login to the admin console you need to have an admin user.  
+To create an admin account with your login and password you need to use environment variables to pass in an 
+initial username and password. This is done by running:
 
     docker run -e KEYCLOAK_USER=<USERNAME> -e KEYCLOAK_PASSWORD=<PASSWORD> jboss/keycloak
+
+When you run the container without the `KEYCLOAK_USER` and `KEYCLOAK_PASSWORD` variables, the username and password 
+of the admin user are generated automatically. You can find the actual username / password of the admin account with:
+    
+    docker logs <CONTAINER> | grep 'Username and password of the Keycloak admin account' -A3
+
+You will see output similar to the following one:
+    
+    docker logs  <CONTAINER> | grep 'Username and password of the Keycloak admin account' -A3
+        Username and password of the Keycloak admin account:
+        KEYCLOAK_USER: admin
+        KEYCLOAK_PASSWORD: 4FC1sqgf#hB1A/NuLn0
 
 You can also create an account on an already running container by running:
 
@@ -34,6 +47,8 @@ You can also create an account on an already running container by running:
 Then restarting the container:
 
     docker restart <CONTAINER>
+
+
 
 ### Providing the username and password via files
 

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -28,6 +28,8 @@ file_env() {
 }
 
 SYS_PROPS=""
+DEFAULT_USER="admin"
+DEFAULT_PASSWORD=$(openssl rand -base64 20 | cut -c-20)
 
 ##################
 # Add admin user #
@@ -35,6 +37,9 @@ SYS_PROPS=""
 
 file_env 'KEYCLOAK_USER'
 file_env 'KEYCLOAK_PASSWORD'
+
+KEYCLOAK_USER=${KEYCLOAK_USER:-$DEFAULT_USER}
+KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD:-$DEFAULT_PASSWORD}
 
 if [[ -n ${KEYCLOAK_USER:-} && -n ${KEYCLOAK_PASSWORD:-} ]]; then
     /opt/jboss/keycloak/bin/add-user-keycloak.sh --user "$KEYCLOAK_USER" --password "$KEYCLOAK_PASSWORD"
@@ -228,6 +233,19 @@ fi
 /opt/jboss/tools/statistics.sh
 /opt/jboss/tools/autorun.sh
 /opt/jboss/tools/vault.sh
+
+##################################
+# Print first login and password #
+##################################
+
+echo "========================================================================="
+echo ""
+echo "  Username and password of the Keycloak admin account:"
+echo "  KEYCLOAK_USER: ${KEYCLOAK_USER}"
+echo "  KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}"
+echo ""
+echo "========================================================================="
+echo ""
 
 ##################
 # Start Keycloak #


### PR DESCRIPTION
Hello!
Small changes that allow to add default user and generate a password for them the user (administrator) did not pass it.

PS
I can't find how to create issue in your Jira.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->