### PR TITLE
Handle databases set via CloudFoundry VCAP_SERVICES

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -153,6 +153,16 @@ if [[ -z ${DB_VENDOR:-} ]]; then
     export DB_VENDOR="h2"
 fi
 
+# Handle VCAP_SERVICES databases
+if [[ ! -z ${DB_VCAP_NAME:-} ]]; then
+    vcap_credentials=$(echo $VCAP_SERVICES | grep -Po '(?<="name": "'${DB_VCAP_NAME}'").*}' | grep -Po '(?<="credentials": { )[^}]*')
+    export DB_ADDR=$(echo $vcap_credentials | grep -Po '(?<="host": ")[^"]+')
+    export DB_PORT=$(echo $vcap_credentials | grep -Po '(?<="port": )\d+')
+    export DB_DATABASE=$(echo $vcap_credentials | grep -Po '(?<="name": ")[^"]+')
+    export DB_USER=$(echo $vcap_credentials | grep -Po '(?<="username": ")[^"]+')
+    export DB_PASSWORD=$(echo $vcap_credentials | grep -Po '(?<="password": ")[^"]+')
+fi
+
 # if the DB_VENDOR is postgres then append port to the DB_ADDR
 function append_port_db_addr() {
   local db_host_regex='^[a-zA-Z0-9]([a-zA-Z0-9]|-|.)*:[0-9]{4,5}$'


### PR DESCRIPTION
* Extract credentials for a datbase names DB_VCAP_NAME
* Use grep to ensure we use existing tools on the current image without
  loading the image with a new tool like jq.
* DB_VENDOR is still set externally so that the script doesn't have to
  guess it correctly

Sorry haven't quite followed the guidelines on contributing.  Just wanted to push an initial PR for comment about my approach.