### PR TITLE
Allow container to be stopped and started

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -489,4 +489,5 @@ For Keycloak built locally you need to first build the distribution then serve i
 
 ## Docker start and stop
 
-This container doesn't support `docker start` and `docker stop` command. See [Keycloak DEV Discussion](https://groups.google.com/d/msg/keycloak-dev/I3qfqTtVmvw/j5RtiBb5AgAJ) for details.
+This image supports `docker start` and `docker stop` commands, but will not detect any changes in configuration.
+If you would like to reconfigure Keycloak, you must create a new container.

--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -223,16 +223,20 @@ echo ""
 echo "========================================================================="
 echo ""
 
-if [ "$DB_VENDOR" != "h2" ]; then
-    /bin/sh /opt/jboss/tools/databases/change-database.sh $DB_VENDOR
-fi
+configured_file="/opt/jboss/configured"
+if [ ! -e "$configured_file" ]; then
+    touch "$configured_file"
 
-/opt/jboss/tools/x509.sh
-/opt/jboss/tools/jgroups.sh
-/opt/jboss/tools/infinispan.sh
-/opt/jboss/tools/statistics.sh
-/opt/jboss/tools/autorun.sh
-/opt/jboss/tools/vault.sh
+    if [ "$DB_VENDOR" != "h2" ]; then
+        /bin/sh /opt/jboss/tools/databases/change-database.sh $DB_VENDOR
+    fi
+    /opt/jboss/tools/x509.sh
+    /opt/jboss/tools/jgroups.sh
+    /opt/jboss/tools/infinispan.sh
+    /opt/jboss/tools/statistics.sh
+    /opt/jboss/tools/autorun.sh
+    /opt/jboss/tools/vault.sh
+fi
 
 ##################
 # Start Keycloak #


### PR DESCRIPTION
This fixes a "duplicate resource error" when restarting a container with a
JGROUPS_DISCOVERY_PROTOCOL, caused by attempting to re-run the configuration
scripts. https://issues.redhat.com/browse/KEYCLOAK-13094

Used @kplantjr's suggestion in comments of #264.

Compose file used for testing:

```yaml
version: '3'
services:

  database:
    image: postgres
    environment:
      POSTGRES_USER: keycloak
      POSTGRES_PASSWORD: insecure

  keycloak:
    image: keycloak-local:fix-1
    depends_on:
    - database
    ports:
      - '8080:8080'
    environment:
      DB_VENDOR: postgres
      DB_ADDR: database
      DB_USER: keycloak
      DB_PASSWORD: insecure
      JGROUPS_DISCOVERY_PROTOCOL: JDBC_PING
      JGROUPS_DISCOVERY_PROPERTIES: datasource_jndi_name=java:jboss/datasources/KeycloakDS,info_writer_sleep_time=1000
```