### PR TITLE
KEYCLOAK-15541 Keycloak docker image fails to connect to MSSQL when p…

### DIFF
--- a/server/tools/cli/databases/mssql/change-database.cli
+++ b/server/tools/cli/databases/mssql/change-database.cli
@@ -1,5 +1,5 @@
 /subsystem=datasources/data-source=KeycloakDS: remove()
-/subsystem=datasources/data-source=KeycloakDS: add(jndi-name=java:jboss/datasources/KeycloakDS,enabled=true,use-java-context=true,use-ccm=true, connection-url="jdbc:sqlserver://${env.DB_ADDR:mssql}:${env.DB_PORT:1433};databaseName=${env.DB_DATABASE:keycloak};sendStringParametersAsUnicode=false;user=${env.DB_USER:keycloak};password=${env.DB_PASSWORD:password};${env.JDBC_PARAMS:}", driver-name=sqlserver)
+/subsystem=datasources/data-source=KeycloakDS: add(jndi-name=java:jboss/datasources/KeycloakDS,enabled=true,use-java-context=true,use-ccm=true, connection-url="jdbc:sqlserver://${env.DB_ADDR:mssql}:${env.DB_PORT:1433};databaseName=${env.DB_DATABASE:keycloak};sendStringParametersAsUnicode=false;${env.JDBC_PARAMS:}", driver-name=sqlserver)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=user-name, value=${env.DB_USER:keycloak})
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=password, value=${env.DB_PASSWORD:password})
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=check-valid-connection-sql, value="SELECT 1")


### PR DESCRIPTION
KEYCLOAK-15541 Keycloak docker image fails to connect to MSSQL when password contains special characters

JIRA issue: https://issues.redhat.com/browse/KEYCLOAK-15541
Mailing list: https://groups.google.com/g/keycloak-dev/c/qh7PG754ThQ

It seems to me that the simplest way how to avoid exception:

```
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: The connection string contains a badly formed name or value.
	at com.microsoft.sqlserver.jdbc//com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:234)
```
when password is like "password}{" is to just remove username and password from JDBC string all together.
