### PR TITLE
Added support for including subordinate CA certificates in keystore

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -438,10 +438,12 @@ Keycloak image allows you to specify both a private key and a certificate for se
 
 * tls.crt - a certificate
 * tls.key - a private key
+* subca.crt - (Optional) an intermediate certificate that issued tls.crt 
 
 Those files need to be mounted in `/etc/x509/https` directory. The image will automatically convert them into a Java keystore and reconfigure Wildfly to use it.
 NOTE: When using volume mounts in containers the files will be mounted in the container as owned by root, as the default permission on the keyfile will most likely be 700 it will result in an empty keystore.
 You will either have to make the key world readable or extend the image to add the keys with the appropriate owner.
+If the tls.crt certificate is issued by a subordinate CA certificate (generally a best practice), you can specify a subordinate CA certificate in the subca.crt file. In many cases, the client application accessing Keycloak will be able to build a full certificate chain even if this file is omitted, but for clients which cannot construct a complete certificate chain, including this file will ensure that Keycloak is sending both the end entity and subordinate CA certificate to clients in the HTTPS handshake.
 
 It is also possible to provide an additional CA bundle and setup Mutual TLS this way. In that case, you need to mount an additional volume (or multiple volumes) to the image. These volumes should contain all necessary `crt` files. The final step is to configure the `X509_CA_BUNDLE` environment variable to contain a list of the locations of the various CA certificate bundle files specified before, separated by space (` `). In case of an OpenShift environment, that could be `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
 


### PR DESCRIPTION
Hi,

I recently opened a discussion on keycloak dev[1] to gauge if there is any interest in adding an additional capability to x509.sh to allow the keycloak HTTPS server to provide a full leaf certificate + subCA certificate in the HTTPS handshake. This helps any clients that don't have subordinate CA certificates setup properly in their truststores to still work correctly.

The following PR addresses this issue by including an optional check to see if a subCA certificate is included in the /etc/x509/https directory  and if one is provided, it adds the subCA certificate as a trusted CA entry in the constructed keystore.

Thanks,
Walter
[1] https://groups.google.com/g/keycloak-dev/c/tCW67VyY-xA
