### PR TITLE
KEYCLOAK-15821 Extend Keycloak boot time

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -465,6 +465,8 @@ Once enabled, you should see the metrics values changing on the `/metrics` endpo
 
 This image extends the [`registry.access.redhat.com/ubi8-minimal`](https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi8-minimal) base image and adds Keycloak and its dependencies on top of it.
 
+Keycloak Container image uses the `MANAGEMENT_TIMEOUT` and `DEPLOYMENT_TIMEOUT` environment variables to specify Wildfly
+deployment timeouts. If you encounter any problems with loading offline sessions, please increase them accordingly.
 
 ## Building image with Keycloak from different sources
 

--- a/server/tools/cli/management-timeout.cli
+++ b/server/tools/cli/management-timeout.cli
@@ -1,0 +1,2 @@
+/system-property=jboss.as.management.blocking.timeout:add(value=${env.MANAGEMENT_TIMEOUT:900})
+/subsystem=deployment-scanner/scanner=default:write-attribute(name=deployment-timeout,value=${env.DEPLOYMENT_TIMEOUT:900})

--- a/server/tools/cli/standalone-configuration.cli
+++ b/server/tools/cli/standalone-configuration.cli
@@ -3,4 +3,5 @@ run-batch --file=/opt/jboss/tools/cli/loglevel.cli
 run-batch --file=/opt/jboss/tools/cli/proxy.cli
 run-batch --file=/opt/jboss/tools/cli/hostname.cli
 run-batch --file=/opt/jboss/tools/cli/theme.cli
+run-batch --file=/opt/jboss/tools/cli/management-timeout.cli
 stop-embedded-server

--- a/server/tools/cli/standalone-ha-configuration.cli
+++ b/server/tools/cli/standalone-ha-configuration.cli
@@ -3,4 +3,5 @@ run-batch --file=/opt/jboss/tools/cli/loglevel.cli
 run-batch --file=/opt/jboss/tools/cli/proxy.cli
 run-batch --file=/opt/jboss/tools/cli/hostname.cli
 run-batch --file=/opt/jboss/tools/cli/theme.cli
+run-batch --file=/opt/jboss/tools/cli/management-timeout.cli
 stop-embedded-server


### PR DESCRIPTION
The implementation of suggestion mentioned in https://access.redhat.com/solutions/1190323

A test image is available via `docker run docker.io/slaskawi/keycloak:keycloak15821`