### PR TITLE
[KEYCLOAK-15899] Set default-provider value for spi vault

### DIFF
--- a/server/tools/cli/files-plaintext-vault.cli
+++ b/server/tools/cli/files-plaintext-vault.cli
@@ -2,5 +2,6 @@ embed-server --server-config=$configuration_file --std-out=discard
 echo ** Adding vault spi **
 /subsystem=keycloak-server/spi=vault/:add
 /subsystem=keycloak-server/spi=vault/provider=files-plaintext/:add(enabled=true,properties={dir => $plaintext_vault_provider_dir})
+/subsystem=keycloak-server/spi=vault:write-attribute(name=default-provider,value=files-plaintext)
 stop-embedded-server
 


### PR DESCRIPTION
According to the [documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#kubernetes-openshift-files-plaintext-vault-provider) the `<spi>` has the `<default-provider>` attribute to select the provider for the vault.

That value seems required to be able to use the vault with OpenShift.
