### PR TITLE
[KEYCLOAK-15900] The docker-entrypoint should run the autorun.sh as last command

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -234,8 +234,8 @@ if [ ! -e "$configured_file" ]; then
     /opt/jboss/tools/jgroups.sh
     /opt/jboss/tools/infinispan.sh
     /opt/jboss/tools/statistics.sh
-    /opt/jboss/tools/autorun.sh
     /opt/jboss/tools/vault.sh
+    /opt/jboss/tools/autorun.sh
 fi
 
 ##################


### PR DESCRIPTION
This allows custom startup scripts to edit all configuration created automatically.