### PR TITLE
KEYCLOAK-16313 remove python packages uninstall code form init-container Dockerfile

### DIFF
--- a/keycloak-init-container/Dockerfile
+++ b/keycloak-init-container/Dockerfile
@@ -4,8 +4,5 @@ FROM registry.access.redhat.com/ubi8-minimal
 
 COPY extensions.sh ./
 
-## We do not allow changing crypto policies in init container from the default one, thus can remove several huge packages with potential for respins
-RUN rpm -e --nodeps platform-python python3-libs platform-python-setuptools && rpm -e python3-pip-wheel python3-setuptools-wheel
-
 CMD [ "./extensions.sh"]
 


### PR DESCRIPTION
- the packages are not part of ubi8-minimal image anymore

https://issues.redhat.com/browse/KEYCLOAK-16313