### PR TITLE
workaround for https://issues.redhat.com/browse/KEYCLOAK-16436  priva…

### DIFF
--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -16,6 +16,7 @@ function autogenerate_keystores() {
     local X509_KEYSTORE_DIR="/etc/x509/${KEYSTORE_TYPE}"
     local X509_CRT="tls.crt"
     local X509_KEY="tls.key"
+    local X509_KEY_PASS=$(< /etc/x509/tls.pass)
     local NAME="keycloak-${KEYSTORE_TYPE}-key"
     local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
     local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
@@ -24,13 +25,23 @@ function autogenerate_keystores() {
     if [ -f "${X509_KEYSTORE_DIR}/${X509_KEY}" ] && [ -f "${X509_KEYSTORE_DIR}/${X509_CRT}" ]; then
 
       echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
-
-      openssl pkcs12 -export \
-      -name "${NAME}" \
-      -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
-      -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
-      -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >& /dev/null
+      if openssl pkey -in "${X509_KEYSTORE_DIR}/${X509_CRT}" -passin pass:the_password -noout; 
+      then
+          openssl pkcs12 -export \
+	     -name "${NAME}" \
+             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+             -password pass:"${PASSWORD}" >& /dev/null
+      else
+          openssl pkcs12 -export \
+	     -name "${NAME}" \
+             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+             -passin pass:"${X509_KEY_PASS}" \
+             -password pass:"${PASSWORD}" >& /dev/null
+      fi
 
       keytool -importkeystore -noprompt \
       -srcalias "${NAME}" -destalias "${NAME}" \


### PR DESCRIPTION
- if the tls.key private key is encrypted, the container skips it and create a new certificate
- this is a minor work around to get the password from **tls.pass** file containing the password that can be mounted as tls.crt, tls.key

