### PR TITLE
checking if "X509_KEY_PASS" exists and process accordingly 

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -438,7 +438,7 @@ Keycloak image allows you to specify both a private key and a certificate for se
 
 * tls.crt - a certificate
 * tls.key - a private key
-* tls.pass - a password-file with one line containing the password for the private key (optional) __**if not provided, the script assumes the private key is not encrypted**__ 
+* X509_KEY_PASS - an Environent variable containing  the password for the private key (optional) __**if not provided, the script assumes the private key is not encrypted**__ 
 
 Those files need to be mounted in `/etc/x509/https` directory. The image will automatically convert them into a Java keystore and reconfigure Wildfly to use it.
 NOTE: When using volume mounts in containers the files will be mounted in the container as owned by root, as the default permission on the keyfile will most likely be 700 it will result in an empty keystore.

--- a/server/README.md
+++ b/server/README.md
@@ -438,6 +438,7 @@ Keycloak image allows you to specify both a private key and a certificate for se
 
 * tls.crt - a certificate
 * tls.key - a private key
+* tls.pass - a password-file with one line containing the password for the private key (optional) __**if not provided, the script assumes the private key is not encrypted**__ 
 
 Those files need to be mounted in `/etc/x509/https` directory. The image will automatically convert them into a Java keystore and reconfigure Wildfly to use it.
 NOTE: When using volume mounts in containers the files will be mounted in the container as owned by root, as the default permission on the keyfile will most likely be 700 it will result in an empty keystore.

--- a/server/tools/keytools.sh
+++ b/server/tools/keytools.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function decrypt_keys() {
+    # read X509_KEY_PASS environment variable if set or use default value: none
+    local X509_KEY_PASSWORD=${X509_KEY_PASS:=""}
+    # Keystore infix notation as used in templates to keystore name mapping
+    declare -A KEYSTORES=( ["https"]="HTTPS" )
+    # Auto-generate the HTTPS keystore if volumes for OpenShift's
+    # serving x509 certificate secrets service were properly mounted
+    for KEYSTORE_TYPE in "${!KEYSTORES[@]}"; do
+
+      local X509_KEYSTORE_DIR="/etc/x509/${KEYSTORE_TYPE}"
+      local X509_CRT="tls.crt"
+      local X509_KEY="tls.key"
+      # read X509_KEY_PASS environment variable if set or use default value: none
+      local X509_KEY_PASSWORD=${X509_KEY_PASS:=""}
+      local NAME="keycloak-${KEYSTORE_TYPE}-key"
+      local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+      local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
+      local PKCS12_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.pk12"
+
+      if [ -f "${X509_KEYSTORE_DIR}/${X509_KEY}" ] && [ -f "${X509_KEYSTORE_DIR}/${X509_CRT}" ]; then
+
+          echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
+          if [ ! -z "$X509_KEY_PASSWORD" ]; then
+              echo "Decrypting ${X509_KEYSTORE_DIR}/${X509_KEY} since X509_KEY_PASS is provided.."
+              openssl pkcs12 -export \
+                 -name "${NAME}" \
+                 -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+                 -passin pass:"${X509_KEY_PASSWORD}" \
+                 -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+                 -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+                 -password pass:"${PASSWORD}" >& /dev/null
+          else
+              openssl pkcs12 -export \
+                  -name "${NAME}" \
+                   -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+                   -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+                   -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+                   -password pass:"${PASSWORD}" >& /dev/null
+          fi
+
+
+
+}

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -16,6 +16,7 @@ function autogenerate_keystores() {
     local X509_KEYSTORE_DIR="/etc/x509/${KEYSTORE_TYPE}"
     local X509_CRT="tls.crt"
     local X509_KEY="tls.key"
+    local X509_KEY_PASS=$(< /etc/x509/tls.pass)
     local NAME="keycloak-${KEYSTORE_TYPE}-key"
     local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
     local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
@@ -24,13 +25,23 @@ function autogenerate_keystores() {
     if [ -f "${X509_KEYSTORE_DIR}/${X509_KEY}" ] && [ -f "${X509_KEYSTORE_DIR}/${X509_CRT}" ]; then
 
       echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
-
-      openssl pkcs12 -export \
-      -name "${NAME}" \
-      -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
-      -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
-      -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >& /dev/null
+      if openssl pkey -in "${X509_KEYSTORE_DIR}/${X509_CRT}" -passin pass:the_password -noout; 
+      then
+          openssl pkcs12 -export \
+	     -name "${NAME}" \
+             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+             -password pass:"${PASSWORD}" >& /dev/null
+      else
+          openssl pkcs12 -export \
+	     -name "${NAME}" \
+             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+             -passin pass:"${X509_KEY_PASS}" \
+             -password pass:"${PASSWORD}" >& /dev/null
+      fi
 
       keytool -importkeystore -noprompt \
       -srcalias "${NAME}" -destalias "${NAME}" \

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -17,7 +17,7 @@ function autogenerate_keystores() {
     local X509_CRT="tls.crt"
     local X509_KEY="tls.key"
     # read X509_KEY_PASS environment variable if set or use default value: none
-    local X509_KEY_PASSWORD=${X509_KEY_PASS:="none"}
+    local X509_KEY_PASSWORD=${X509_KEY_PASS:=""}
     local NAME="keycloak-${KEYSTORE_TYPE}-key"
     local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
     local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
@@ -26,7 +26,7 @@ function autogenerate_keystores() {
     if [ -f "${X509_KEYSTORE_DIR}/${X509_KEY}" ] && [ -f "${X509_KEYSTORE_DIR}/${X509_CRT}" ]; then
 
         echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
-        if [ ! "$X509_KEY_PASSWORD" = "none" ]; then
+        if [ ! -z "$X509_KEY_PASSWORD" ]; then
             echo "Decrypting ${X509_KEYSTORE_DIR}/${X509_KEY} since X509_KEY_PASS is provided.."
             openssl pkcs12 -export \
                -name "${NAME}" \

--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -16,7 +16,7 @@ function autogenerate_keystores() {
     local X509_KEYSTORE_DIR="/etc/x509/${KEYSTORE_TYPE}"
     local X509_CRT="tls.crt"
     local X509_KEY="tls.key"
-    local X509_KEY_PASS=$(< /etc/x509/tls.pass)
+    local X509_PASS="tls.pass"
     local NAME="keycloak-${KEYSTORE_TYPE}-key"
     local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
     local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
@@ -24,24 +24,24 @@ function autogenerate_keystores() {
 
     if [ -f "${X509_KEYSTORE_DIR}/${X509_KEY}" ] && [ -f "${X509_KEYSTORE_DIR}/${X509_CRT}" ]; then
 
-      echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
-      if openssl pkey -in "${X509_KEYSTORE_DIR}/${X509_CRT}" -passin pass:the_password -noout; 
-      then
-          openssl pkcs12 -export \
-	     -name "${NAME}" \
-             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
-             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
-             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
-             -password pass:"${PASSWORD}" >& /dev/null
-      else
-          openssl pkcs12 -export \
-	     -name "${NAME}" \
-             -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
-             -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
-             -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
-             -passin pass:"${X509_KEY_PASS}" \
-             -password pass:"${PASSWORD}" >& /dev/null
-      fi
+        echo "Creating ${KEYSTORES[$KEYSTORE_TYPE]} keystore via OpenShift's service serving x509 certificate secrets.."
+        if [ -f "${X509_KEYSTORE_DIR}/${X509_PASS}" ]; then
+            local X509_KEY_PASS=$(< "${X509_KEYSTORE_DIR}/${X509_PASS}")
+            openssl pkcs12 -export \
+               -name "${NAME}" \
+               -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+               -passin pass:"${X509_KEY_PASS}" \
+               -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+               -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+               -password pass:"${PASSWORD}" >& /dev/null
+        else
+            openssl pkcs12 -export \
+                -name "${NAME}" \
+                 -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
+                 -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
+                 -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
+                 -password pass:"${PASSWORD}" >& /dev/null
+        fi
 
       keytool -importkeystore -noprompt \
       -srcalias "${NAME}" -destalias "${NAME}" \


### PR DESCRIPTION
- Documentation is updated
- Tested with two different keys (encrypted  +tls.pass and non-encrypted without tls.pass)
https://issues.redhat.com/browse/KEYCLOAK-16436


