### PR TITLE
Fix upload script profile name.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -312,9 +312,9 @@ Additional server startup options (extension of JAVA_OPTS) can be configured usi
 
 ### Example
 
-Enable _upload_script_ profile:
+Enable _upload_scripts_ profile:
 
-    docker run -e JAVA_OPTS_APPEND="-Dkeycloak.profile.feature.upload_script=enabled" jboss/keycloak
+    docker run -e JAVA_OPTS_APPEND="-Dkeycloak.profile.feature.upload_scripts=enabled" jboss/keycloak
 
 
 ## Clustering


### PR DESCRIPTION
According to https://www.keycloak.org/docs/latest/server_installation/#profiles the name of the (deprecated) upload script profile is `upload_scripts`.
