### PR TITLE
KEYCLOAK-17354 respond to tls CertificateRequest

### DIFF
--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -17,7 +17,7 @@ function autogenerate_keystores() {
     local X509_CRT="tls.crt"
     local X509_KEY="tls.key"
     local NAME="keycloak-${KEYSTORE_TYPE}-key"
-    local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+    local KEYSTORE_PASSWORD=$(openssl rand -base64 32 2>/dev/null)
     local JKS_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.jks"
     local PKCS12_KEYSTORE_FILE="${KEYSTORE_TYPE}-keystore.pk12"
 
@@ -30,14 +30,14 @@ function autogenerate_keystores() {
       -inkey "${X509_KEYSTORE_DIR}/${X509_KEY}" \
       -in "${X509_KEYSTORE_DIR}/${X509_CRT}" \
       -out "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >& /dev/null
+      -password pass:"${KEYSTORE_PASSWORD}" >& /dev/null
 
       keytool -importkeystore -noprompt \
       -srcalias "${NAME}" -destalias "${NAME}" \
       -srckeystore "${KEYSTORES_STORAGE}/${PKCS12_KEYSTORE_FILE}" \
       -srcstoretype pkcs12 \
       -destkeystore "${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" \
-      -storepass "${PASSWORD}" -srcstorepass "${PASSWORD}" >& /dev/null
+      -storepass "${KEYSTORE_PASSWORD}" -srcstorepass "${KEYSTORE_PASSWORD}" >& /dev/null
 
       if [ -f "${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" ]; then
         echo "${KEYSTORES[$KEYSTORE_TYPE]} keystore successfully created at: ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}"
@@ -45,7 +45,7 @@ function autogenerate_keystores() {
         echo "${KEYSTORES[$KEYSTORE_TYPE]} keystore not created at: ${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE} (check permissions?)"
       fi
 
-      echo "set keycloak_tls_keystore_password=${PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
+      echo "set keycloak_tls_keystore_password=${KEYSTORE_PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
       echo "set keycloak_tls_keystore_file=${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE}" >> "$JBOSS_HOME/bin/.jbossclirc"
       echo "set configuration_file=standalone.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
       $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-keystore.cli >& /dev/null
@@ -53,6 +53,13 @@ function autogenerate_keystores() {
       echo "set configuration_file=standalone-ha.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
       $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-keystore.cli >& /dev/null
       sed -i '$ d' "$JBOSS_HOME/bin/.jbossclirc"
+
+      echo "JAVA_OPTS=\"\$JAVA_OPTS "\
+"-Djavax.net.ssl.keyStoreType=pkcs12 "\
+"-Djavax.net.ssl.keyStore=${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE} "\
+"-Djavax.net.ssl.keyStorePassword=${KEYSTORE_PASSWORD} "\
+"-Dkeycloak.tls.keystore.path=${KEYSTORES_STORAGE}/${JKS_KEYSTORE_FILE} "\
+"-Dkeycloak.tls.keystore.password=${KEYSTORE_PASSWORD}\"" >> /opt/jboss/keycloak/bin/standalone.conf
     fi
 
   done
@@ -61,7 +68,7 @@ function autogenerate_keystores() {
   local -r X509_CRT_DELIMITER="/-----BEGIN CERTIFICATE-----/"
   local JKS_TRUSTSTORE_FILE="truststore.jks"
   local JKS_TRUSTSTORE_PATH="${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}"
-  local PASSWORD=$(openssl rand -base64 32 2>/dev/null)
+  local TRUSTSTORE_PASSWORD=$(openssl rand -base64 32 2>/dev/null)
   local TEMPORARY_CERTIFICATE="temporary_ca.crt"
   if [ -n "${X509_CA_BUNDLE}" ]; then
     pushd /tmp >& /dev/null
@@ -74,7 +81,7 @@ function autogenerate_keystores() {
     csplit -s -z -f crt- "${TEMPORARY_CERTIFICATE}" "${X509_CRT_DELIMITER}" '{*}'
     for CERT_FILE in crt-*; do
       keytool -import -noprompt -keystore "${JKS_TRUSTSTORE_PATH}" -file "${CERT_FILE}" \
-      -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null
+      -storepass "${TRUSTSTORE_PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null
     done
 
     if [ -f "${JKS_TRUSTSTORE_PATH}" ]; then
@@ -82,8 +89,7 @@ function autogenerate_keystores() {
     else
       echo "Keycloak truststore not created at: ${JKS_TRUSTSTORE_PATH}"
     fi
-
-    # Import existing system CA certificates into the newly generated truststore
+# Import existing system CA certificates into the newly generated truststore
     local SYSTEM_CACERTS=$(readlink -e $(dirname $(readlink -e $(which keytool)))"/../lib/security/cacerts")
     if keytool -v -list -keystore "${SYSTEM_CACERTS}" -storepass "changeit" > /dev/null; then
       echo "Importing certificates from system's Java CA certificate bundle into Keycloak truststore.."
@@ -91,7 +97,7 @@ function autogenerate_keystores() {
       -srckeystore "${SYSTEM_CACERTS}" \
       -destkeystore "${JKS_TRUSTSTORE_PATH}" \
       -srcstoretype jks -deststoretype jks \
-      -storepass "${PASSWORD}" -srcstorepass "changeit" >& /dev/null
+      -storepass "${TRUSTSTORE_PASSWORD}" -srcstorepass "changeit" >& /dev/null
       if [ "$?" -eq "0" ]; then
         echo "Successfully imported certificates from system's Java CA certificate bundle into Keycloak truststore at: ${JKS_TRUSTSTORE_PATH}"
       else
@@ -99,7 +105,7 @@ function autogenerate_keystores() {
       fi
     fi
 
-    echo "set keycloak_tls_truststore_password=${PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
+    echo "set keycloak_tls_truststore_password=${TRUSTSTORE_PASSWORD}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_tls_truststore_file=${KEYSTORES_STORAGE}/${JKS_TRUSTSTORE_FILE}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set configuration_file=standalone.xml" >> "$JBOSS_HOME/bin/.jbossclirc"
     $JBOSS_HOME/bin/jboss-cli.sh --file=/opt/jboss/tools/cli/x509-truststore.cli >& /dev/null


### PR DESCRIPTION
Set certificate to respond to CertificateRequest for ldaps and starttls requests when LDAP server requires client certificate verification.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
