### PR TITLE
KEYCLOAK-17833 keycloak init image does not pick package updates while respin

### DIFF
--- a/keycloak-init-container/Dockerfile
+++ b/keycloak-init-container/Dockerfile
@@ -2,6 +2,8 @@ FROM registry.access.redhat.com/ubi8-minimal
 
 ##LABELS
 
+RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum/*
+
 COPY extensions.sh ./
 
 CMD [ "./extensions.sh"]


### PR DESCRIPTION
During the image respin I have spot the issue. This is the upstream fix.

https://issues.redhat.com/browse/KEYCLOAK-17833