### PR TITLE
Support for ignoring SSL certificate error

### DIFF
--- a/keycloak-init-container/extensions.sh
+++ b/keycloak-init-container/extensions.sh
@@ -15,7 +15,7 @@ download_extension() {
     fi
     echo 
     echo "Downloading extension from $EXTENSION_URL"
-    local CURL_COMMAND="$(curl --verbose --location  --remote-name --remote-header-name --write-out "%{http_code} %{filename_effective}"  --silent "$EXTENSION_URL" 2> /tmp/headers)"
+    local CURL_COMMAND="$(curl --verbose --location --insecure --remote-name --remote-header-name --write-out "%{http_code} %{filename_effective}"  --silent "$EXTENSION_URL" 2> /tmp/headers)"
   
     local STATUS_CODE=${CURL_COMMAND:0:3}
 


### PR DESCRIPTION
Added --insecure parameter to ignore SSL certificate errors while downloading the extensions.

