### PR TITLE
Add env variable for importing realm from directory

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -72,6 +72,13 @@ if [[ -n ${KEYCLOAK_IMPORT:-} ]]; then
     SYS_PROPS+=" -Dkeycloak.import=$KEYCLOAK_IMPORT"
 fi
 
+if [[ -n ${KEYCLOAK_IMPORT_FROM_DIRECTORY:-} ]]; then
+    SYS_PROPS+=" -Dkeycloak.migration.action=import"
+    SYS_PROPS+=" -Dkeycloak.migration.provider=dir"
+    SYS_PROPS+=" -Dkeycloak.migration.strategy=OVERWRITE_EXISTING"
+    SYS_PROPS+=" -Dkeycloak.migration.dir=$KEYCLOAK_IMPORT_DIRECTORY"
+fi
+
 ########################
 # JGroups bind options #
 ########################


### PR DESCRIPTION
I have to use different realm import settings and I don't want to override any XML configurations or oodles of CMD params.
Why don't you add some more useful env variables which will ease keycloak configuration in docker compose?

