### PR TITLE
KEYCLOAK-13262 Implement statistics switch for Infinispan

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -454,6 +454,7 @@ You can enable it with the KEYCLOAK_STATISTICS environment variables which take 
 * `db` for the `datasources` subsystem
 * `http` for the `undertow` subsystem
 * `jgroups` for the `jgroups` subsystem
+* `infinispan` for the `infinispan` subsystem (and all caches)
 
 for instance, `KEYCLOAK_STATISTICS=db,http` will enable statistics for the datasources and undertow subsystem.
 

--- a/server/tools/cli/metrics/infinispan.cli
+++ b/server/tools/cli/metrics/infinispan.cli
@@ -1,0 +1,12 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+batch
+/subsystem=infinispan/cache-container=keycloak/: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=sessions: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineSessions: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=loginFailures: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=clientSessions: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineClientSessions: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=actionTokens: write-attribute(name=statistics-enabled, value=true)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=authenticationSessions: write-attribute(name=statistics-enabled, value=true)
+run-batch
+stop-embedded-server


### PR DESCRIPTION
This allows to enable metrics/statistics for infinispan subsystem and caches

Besides [KEYCLOAK-13262](https://issues.redhat.com/browse/KEYCLOAK-13262) this also addresses [KEYCLOAK-16331](https://issues.redhat.com/browse/KEYCLOAK-16331)