### PR TITLE
use file_env for DB_ADDR, DB_VENDOR

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -118,6 +118,9 @@ if [[ -n ${DB_VENDOR:-} ]]; then
   DB_VENDOR=$(echo "$DB_VENDOR" | tr "[:upper:]" "[:lower:]")
 fi
 
+file_env 'DB_ADDR'
+file_env 'DB_VENDOR'
+
 # Detect DB vendor from default host names
 if [[ -z ${DB_VENDOR:-} ]]; then
     if (getent hosts postgres &>/dev/null); then


### PR DESCRIPTION
Hi,

I am using docker secrets for my keycloak deployment. As I am automating everything I also want to set the DB_ADDR via docker secrets. This PR adds the possibility to set DB_ADDR and DB_VENDOR via docker secrets.

I am looking forward to read your comments.
