### PR TITLE
Added a default healthcheck to Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,3 +30,5 @@ EXPOSE 8443
 ENTRYPOINT [ "/opt/jboss/tools/docker-entrypoint.sh" ]
 
 CMD ["-b", "0.0.0.0"]
+
+HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=3 CMD curl --fail http://localhost:8080/auth/realms/master


### PR DESCRIPTION
Adds a default `HEALTHCHECK` to be able to monitor the health of the container. A user can always change it should they need to, in their docker-compose file.

I specifically chose a start period of `30s` because the image loads quite slow sometimes, even on SSD.