### PR TITLE
CIAM-1672 Set compose section in init container.yaml to avoid unsigned RPMs

### DIFF
--- a/keycloak-init-container/container.yaml
+++ b/keycloak-init-container/container.yaml
@@ -1,3 +1,7 @@
+compose:
+  inherit: true
+  pulp_repos: true
+  signing_intent: release
 platforms:
   only:
     - x86_64


### PR DESCRIPTION
Without a compose section, the `microdnf update` present in the Dockerfile can result in unsigned RPMs being pulled into the image, resulting in an invalid image