### PR TITLE
docker-entrypoint removes add-user.json

### DIFF
--- a/server/tools/docker-entrypoint.sh
+++ b/server/tools/docker-entrypoint.sh
@@ -37,6 +37,12 @@ file_env 'KEYCLOAK_USER'
 file_env 'KEYCLOAK_PASSWORD'
 
 if [[ -n ${KEYCLOAK_USER:-} && -n ${KEYCLOAK_PASSWORD:-} ]]; then
+    
+    add_user_json="/opt/jboss/keycloak/standalone/configuration/keycloak-add-user.json"
+    if [ -e "$add_user_json" ]; then
+        rm "$add_user_json"
+    fi
+    
     /opt/jboss/keycloak/bin/add-user-keycloak.sh --user "$KEYCLOAK_USER" --password "$KEYCLOAK_PASSWORD"
 fi
 


### PR DESCRIPTION
Docker-entrypoint.sh removes old add-user.json before adding the admin user.
This prevents a bug upon container restart: https://github.com/keycloak/keycloak/issues/9178

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
