### PR TITLE
Removed duplicate of failureThreshold

### DIFF
--- a/openshift-examples/keycloak-https-mutual-tls.json
+++ b/openshift-examples/keycloak-https-mutual-tls.json
@@ -212,7 +212,6 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "failureThreshold": 3,
                                     "httpGet": {
                                         "path": "/",
                                         "port": 8080,

--- a/openshift-examples/keycloak-https.json
+++ b/openshift-examples/keycloak-https.json
@@ -211,7 +211,6 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "failureThreshold": 3,
                                     "httpGet": {
                                         "path": "/auth/realms/master",
                                         "port": 8080,


### PR DESCRIPTION
The value failureThreshold was defined twice so the template was not useable by openshift.