### PR TITLE
#365 Adding JGROUPS_DISCOVERY_CLI_LOGGING environment variable

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -424,6 +424,21 @@ Log level can also be changed at runtime, for example (assuming docker exec acce
     ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/root-logger=ROOT:change-root-log-level(level=DEBUG)'
     ./keycloak/bin/jboss-cli.sh --connect --command='/subsystem=logging/logger=org.keycloak:write-attribute(name=level,value=DEBUG)'
 
+### Debugging jgroups discovery
+
+if `JGROUPS_DISCOVERY_PROTOCOL` is set, the container will look for a
+discovery script in
+
+    /opt/jboss/tools/cli/jgroups/discovery/[protocol].cli
+
+If that file doesn't exist, a `default.cli` script will be run instead.
+
+Normally the output from these scripts is discarded.  However if you wish to
+debug these scripts you can send the output to stderr/stdout by setting the
+environment variable:
+
+    JGROUPS_DISCOVERY_CLI_LOGGING=true
+
 ### Enabling proxy address forwarding
 
 When running Keycloak behind a proxy, you will need to enable proxy address forwarding.

--- a/server/tools/jgroups.sh
+++ b/server/tools/jgroups.sh
@@ -21,10 +21,17 @@ if [ -n "$JGROUPS_DISCOVERY_PROTOCOL" ]; then
     echo "set keycloak_jgroups_discovery_protocol=${JGROUPS_DISCOVERY_PROTOCOL}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_jgroups_discovery_protocol_properties=${JGROUPS_DISCOVERY_PROPERTIES_PARSED}" >> "$JBOSS_HOME/bin/.jbossclirc"
     echo "set keycloak_jgroups_transport_stack=${JGROUPS_TRANSPORT_STACK:-tcp}" >> "$JBOSS_HOME/bin/.jbossclirc"
+
+    # For the remainder of the script, display the output of calls if
+    # JGROUPS_DISCOVERY_CLI_LOGGING is set to ON.  Otherwise send it to null.
+    if [ "${JGROUPS_DISCOVERY_CLI_LOGGING-}" != "true" ] ; then
+      exec &>/dev/null
+    fi
+
     # If there's a specific CLI file for given protocol - execute it. If not, we should be good with the default one.
     if [ -f "/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" ]; then
-       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli" >& /dev/null
+       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/$JGROUPS_DISCOVERY_PROTOCOL.cli"
     else
-       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/default.cli" >& /dev/null
+       $JBOSS_HOME/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/default.cli"
     fi
 fi


### PR DESCRIPTION
If set to true, output from discovery CLI scripts will be sent to stdout/stderr instead of /dev/null.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
