### PR TITLE
Add -storetype jks to keytool command

### DIFF
--- a/server/tools/x509.sh
+++ b/server/tools/x509.sh
@@ -74,7 +74,7 @@ function autogenerate_keystores() {
     csplit -s -z -f crt- "${TEMPORARY_CERTIFICATE}" "${X509_CRT_DELIMITER}" '{*}'
     for CERT_FILE in crt-*; do
       keytool -import -noprompt -keystore "${JKS_TRUSTSTORE_PATH}" -file "${CERT_FILE}" \
-      -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" >& /dev/null
+      -storepass "${PASSWORD}" -alias "service-${CERT_FILE}" -storetype jks >& /dev/null
     done
 
     if [ -f "${JKS_TRUSTSTORE_PATH}" ]; then


### PR DESCRIPTION
On FIPS enabled systems keytool would attempt to use the pkcs11
configuration which is in read only mode, and would fail to create the
trust store.

Bypassing that with the -storetype flag means that Keytool will
successfuly create the keystore.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
